### PR TITLE
Update the examples of inferred types.

### DIFF
--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -278,8 +278,8 @@ from an expression as follows:
 ```lean
 #check fun (x : Nat) => x + 5   -- Nat → Nat
 #check λ (x : Nat) => x + 5     -- λ and fun mean the same thing
-#check fun x : Nat => x + 5     -- Nat inferred
-#check λ x : Nat => x + 5       -- Nat inferred
+#check fun x => x + 5           -- Nat inferred
+#check λ x => x + 5             -- Nat inferred
 ```
 
 You can evaluate a lambda function by passing the required parameters:


### PR DESCRIPTION
The current examples of interfered types in lambda expressions contain types. Remove these types to avoid confusion.