### PR TITLE
Removes an unused variable in a Chapter 5 example.

### DIFF
--- a/tactics.md
+++ b/tactics.md
@@ -1140,8 +1140,7 @@ number of identities in Lean's library have been tagged with the
 rewrite subterms in an expression.
 
 ```lean
-example (x y z : Nat) (p : Nat → Prop) (h : p (x * y))
-        : (x + 0) * (0 + y * 1 + z * 0) = x * y := by
+example (x y z : Nat) : (x + 0) * (0 + y * 1 + z * 0) = x * y := by
   simp
 
 example (x y z : Nat) (p : Nat → Prop) (h : p (x * y))


### PR DESCRIPTION
I was going through the chapter on tactics and noticed what looks like a minor copy/paste redundancy.