### PR TITLE
fix typo in variable declaration in example

### DIFF
--- a/propositions_and_proofs.md
+++ b/propositions_and_proofs.md
@@ -603,7 +603,7 @@ contradiction. This rule is sometimes called *ex falso* (short for *ex
 falso sequitur quodlibet*), or the *principle of explosion*.
 
 ```lean
-variable (tp q : Prop)
+variable (p q : Prop)
 
 example (hp : p) (hnp : ¬p) : q := False.elim (hnp hp)
 ```


### PR DESCRIPTION
I noticed this while learning lean through the documentation. 
The declaration of `tp` seems like a typo to me.