### PR TITLE
typo: add -> app

### DIFF
--- a/interacting_with_lean.md
+++ b/interacting_with_lean.md
@@ -953,7 +953,7 @@ This feature combined with named arguments is useful for writing patterns. Here 
 inductive Term where
   | var    (name : String)
   | num    (val : Nat)
-  | add    (fn : Term) (arg : Term)
+  | app    (fn : Term) (arg : Term)
   | lambda (name : String) (type : Term) (body : Term)
 
 def getBinderName : Term → Option String


### PR DESCRIPTION
The name of the constructor should be `app` rather than `add` according to the context