### PR TITLE
suggest to more appropriate symbol

### DIFF
--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -905,12 +905,12 @@ def g (α : Type u) (β : α → Type v) (a : α) (b : β a) : Σ a : α, β a :
   Sigma.mk a b
 
 def h1 (x : Nat) : Nat :=
-  (f Type (fun α => α) Nat x).2
+  (f Type (fun a => a) Nat x).2
 
 #eval h1 5 -- 5
 
 def h2 (x : Nat) : Nat :=
-  (g Type (fun α => α) Nat x).2
+  (g Type (fun a => a) Nat x).2
 
 #eval h2 5 -- 5
 ```


### PR DESCRIPTION
Modifying character for clarity.
I don't think we should use the same character in both the parameter and the type signature.