### PR TITLE
chore: update `calc` to use underscore-in-first-lhs notation

### DIFF
--- a/axioms_and_computation.md
+++ b/axioms_and_computation.md
@@ -1099,8 +1099,9 @@ theorem linv_comp_self {f : α → β} [Inhabited α]
   funext fun a =>
     have ex  : ∃ a₁ : α, f a₁ = f a := ⟨a, rfl⟩
     have feq : f (choose ex) = f a  := choose_spec ex
-    calc linv f (f a) = choose ex := dif_pos ex
-               _      = a         := inj feq
+    calc linv f (f a)
+      _ = choose ex := dif_pos ex
+      _ = a         := inj feq
 ```
 
 From a classical point of view, ``linv`` is a function. From a

--- a/inductive_types.md
+++ b/inductive_types.md
@@ -838,9 +838,9 @@ theorem zero_add (n : Nat) : 0 + n = n :=
    (show 0 + 0 = 0 from rfl)
    (fun (n : Nat) (ih : 0 + n = n) =>
     show 0 + succ n = succ n from
-    calc
-       0 + succ n = succ (0 + n) := rfl
-                _ = succ n       := by rw [ih])
+    calc 0 + succ n
+      _ = succ (0 + n) := rfl
+      _ = succ n       := by rw [ih])
 # end Hidden
 ```
 
@@ -874,11 +874,11 @@ theorem add_assoc (m n k : Nat) : m + n + k = m + (n + k) :=
     (show m + n + 0 = m + (n + 0) from rfl)
     (fun k (ih : m + n + k = m + (n + k)) =>
       show m + n + succ k = m + (n + succ k) from
-      calc
-          m + n + succ k = succ (m + n + k) := rfl
-            _ = succ (m + (n + k)) := by rw [ih]
-            _ = m + succ (n + k) := rfl
-            _ = m + (n + succ k) := rfl)
+      calc m + n + succ k
+        _ = succ (m + n + k)   := rfl
+        _ = succ (m + (n + k)) := by rw [ih]
+        _ = m + succ (n + k)   := rfl
+        _ = m + (n + succ k)   := rfl)
 # end Hidden
 ```
 
@@ -901,9 +901,10 @@ theorem add_comm (m n : Nat) : m + n = n + m :=
    (show m + 0 = 0 + m by rw [Nat.zero_add, Nat.add_zero])
    (fun (n : Nat) (ih : m + n = n + m) =>
     show m + succ n = succ n + m from
-    calc m + succ n = succ (m + n) := rfl
-                  _ = succ (n + m) := by rw [ih]
-                  _ = succ n + m   := sorry)
+    calc m + succ n
+      _ = succ (m + n) := rfl
+      _ = succ (n + m) := by rw [ih]
+      _ = succ n + m   := sorry)
 ```
 
 At this point, we see that we need another supporting fact, namely, that ``succ (n + m) = succ n + m``.
@@ -917,9 +918,10 @@ theorem succ_add (n m : Nat) : succ n + m = succ (n + m) :=
     (show succ n + 0 = succ (n + 0) from rfl)
     (fun (m : Nat) (ih : succ n + m = succ (n + m)) =>
      show succ n + succ m = succ (n + succ m) from
-     calc succ n + succ m = succ (succ n + m) := rfl
-           _  = succ (succ (n + m))           := by rw [ih]
-           _  = succ (n + succ m)             := rfl)
+     calc succ n + succ m
+       _ = succ (succ n + m)   := rfl
+       _ = succ (succ (n + m)) := by rw [ih]
+       _ = succ (n + succ m)   := rfl)
 ```
 
 You can then replace the ``sorry`` in the previous proof with ``succ_add``. Yet again, the proofs can be compressed:

--- a/quantifiers_and_equality.md
+++ b/quantifiers_and_equality.md
@@ -358,6 +358,17 @@ calc
 
 Each ``<proof>_i`` is a proof for ``<expr>_{i-1} op_i <expr>_i``.
 
+We can also use `_` in the first relation (right after `<expr>_0`)
+which is useful to align the sequence of relation/proof pairs:
+
+```
+calc <expr>_0 
+    '_' 'op_1' <expr>_1 ':=' <proof>_1
+    '_' 'op_2' <expr>_2 ':=' <proof>_2
+    ...
+    '_' 'op_n' <expr>_n ':=' <proof>_n
+```
+
 Here is an example:
 
 ```lean
@@ -507,9 +518,22 @@ natural and perspicuous way.
 example (x y : Nat) : (x + y) * (x + y) = x * x + y * x + x * y + y * y :=
   calc
     (x + y) * (x + y) = (x + y) * x + (x + y) * y  := by rw [Nat.mul_add]
-        _ = x * x + y * x + (x + y) * y            := by rw [Nat.add_mul]
-        _ = x * x + y * x + (x * y + y * y)        := by rw [Nat.add_mul]
-        _ = x * x + y * x + x * y + y * y          := by rw [←Nat.add_assoc]
+    _ = x * x + y * x + (x + y) * y                := by rw [Nat.add_mul]
+    _ = x * x + y * x + (x * y + y * y)            := by rw [Nat.add_mul]
+    _ = x * x + y * x + x * y + y * y              := by rw [←Nat.add_assoc]
+```
+
+The alternative `calc` notation is worth considering here. When the
+first expression is taking this much space, using `_` in the first
+relation naturally aligns all relations:
+
+```lean
+example (x y : Nat) : (x + y) * (x + y) = x * x + y * x + x * y + y * y :=
+  calc (x + y) * (x + y)
+    _ = (x + y) * x + (x + y) * y       := by rw [Nat.mul_add]
+    _ = x * x + y * x + (x + y) * y     := by rw [Nat.add_mul]
+    _ = x * x + y * x + (x * y + y * y) := by rw [Nat.add_mul]
+    _ = x * x + y * x + x * y + y * y   := by rw [←Nat.add_assoc]
 ```
 
 Here the left arrow before ``Nat.add_assoc`` tells rewrite to use the
@@ -696,9 +720,9 @@ theorem even_plus_even (h1 : is_even a) (h2 : is_even b) : is_even (a + b) :=
   Exists.elim h1 (fun w1 (hw1 : a = 2 * w1) =>
   Exists.elim h2 (fun w2 (hw2 : b = 2 * w2) =>
     Exists.intro (w1 + w2)
-      (calc
-        a + b = 2 * w1 + 2 * w2  := by rw [hw1, hw2]
-          _   = 2 * (w1 + w2)    := by rw [Nat.mul_add])))
+      (calc a + b
+        _ = 2 * w1 + 2 * w2 := by rw [hw1, hw2]
+        _ = 2 * (w1 + w2)   := by rw [Nat.mul_add])))
 ```
 
 Using the various gadgets described in this chapter --- the match

--- a/quantifiers_and_equality.md
+++ b/quantifiers_and_equality.md
@@ -351,14 +351,15 @@ equality. In Lean, a calculational proof starts with the keyword
 ```
 calc
   <expr>_0  'op_1'  <expr>_1  ':='  <proof>_1
-    '_'     'op_2'  <expr>_2  ':='  <proof>_2
-    ...
-    '_'     'op_n'  <expr>_n  ':='  <proof>_n
+  '_'       'op_2'  <expr>_2  ':='  <proof>_2
+  ...
+  '_'       'op_n'  <expr>_n  ':='  <proof>_n
 ```
 
-Each ``<proof>_i`` is a proof for ``<expr>_{i-1} op_i <expr>_i``.
+Note that the `calc` relations all have the same indentation. Each
+``<proof>_i`` is a proof for ``<expr>_{i-1} op_i <expr>_i``.
 
-We can also use `_` in the first relation (right after `<expr>_0`)
+We can also use `_` in the first relation (right after ``<expr>_0``)
 which is useful to align the sequence of relation/proof pairs:
 
 ```

--- a/type_classes.md
+++ b/type_classes.md
@@ -1060,8 +1060,9 @@ theorem resp_mul {S1 S2 : Semigroup} (f : Morphism S1 S2) (a b : S1)
 
 example (S1 S2 : Semigroup) (f : Morphism S1 S2) (a : S1) :
       f (a * a * a) = f a * f a * f a :=
-  calc f (a * a * a) = f (a * a) * f a := by rw [resp_mul f]
-                _    = f a * f a * f a := by rw [resp_mul f]
+  calc f (a * a * a)
+    _ = f (a * a) * f a := by rw [resp_mul f]
+    _ = f a * f a * f a := by rw [resp_mul f]
 ```
 
 With the coercion in place, we can write ``f (a * a * a)`` instead of ``f.mor (a * a * a)``. When the ``Morphism``, ``f``, is used where a function is expected, Lean inserts the coercion. Similar to ``CoeSort``, we have yet another class ``CoeFun`` for this class of coercions. The field ``F`` is used to specify the function type we are coercing to. This type may depend on the type we are coercing from.


### PR DESCRIPTION
[Lean 4's PR 1844](https://github.com/leanprover/lean4/pull/1844) modifies the `calc` notation (term and tactic versions). As a result, arbitrary indentation in `calc` relations is not allowed anymore, which is oftentimes used to (try to) align relations/proofs:

```lean
example (x y : Nat) : (x + y) * (x + y) = x * x + y * x + x * y + y * y :=
  calc
    (x + y) * (x + y) = (x + y) * x + (x + y) * y  := by rw [Nat.mul_add]
        -- improper indentation
        _ = x * x + y * x + (x + y) * y            := by rw [Nat.add_mul]
        _ = x * x + y * x + (x * y + y * y)        := by rw [Nat.add_mul]
        _ = x * x + y * x + x * y + y * y          := by rw [←Nat.add_assoc]
```

To compensate, [PR 1844](https://github.com/leanprover/lean4/pull/1844) allows an alternate syntax where `_` can be use in the first relation:

```lean
example (x y : Nat) : (x + y) * (x + y) = x * x + y * x + x * y + y * y :=
  calc (x + y) * (x + y)
    _ = (x + y) * x + (x + y) * y       := by rw [Nat.mul_add]
    _ = x * x + y * x + (x + y) * y     := by rw [Nat.add_mul]
    _ = x * x + y * x + (x * y + y * y) := by rw [Nat.add_mul]
    _ = x * x + y * x + x * y + y * y   := by rw [←Nat.add_assoc]
```

This PR discusses this alternate notation in the "Quantifiers and Equality" section, when `calc` is first discussed, and fixes `calc` code samples that use improper indentation with this new syntax.