### PR TITLE
add links to tutorials

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -45,7 +45,7 @@ Lean's underlying logic has a computational interpretation, and Lean can be view
 language. More to the point, it can be viewed as a system for writing programs with a precise semantics, as well as
 reasoning about the functions that the programs compute. Lean also has mechanisms to serve as its own *metaprogramming
 language*, which means that you can implement automation and extend the functionality of Lean using Lean itself. These
-aspects of Lean are explored in a companion tutorial to this one, [Programming in Lean 4](TBD), though computational
+aspects of Lean are explored in two companion tutorials, [Functional Programming in Lean](https://leanprover.github.io/functional_programming_in_lean/) and [Metaprogramming in Lean 4](https://github.com/arthurpaulino/lean4-metaprogramming-book), though computational
 aspects of the system will make an appearance here.
 
 About Lean


### PR DESCRIPTION
Add links to FPiL and the metaprogramming book.

Fixes #28.

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/add.20links.20to.20other.20lean.20tutorials.20to.20tpil4