### PR TITLE
Update type_classes.md

### DIFF
--- a/type_classes.md
+++ b/type_classes.md
@@ -92,7 +92,7 @@ We can now reimplement `double` using an instance implicit by:
 # instance : Add Nat where
 #  add := Nat.add
 # instance : Add Int where
-#  add := Int.add
+#  add := Int.mul
 # instance : Add Float where
 #  add := Float.add
 def double [Add a] (x : a) : a :=


### PR DESCRIPTION
In https://lean-lang.org/theorem_proving_in_lean4/type_classes.html I notieced an error. In the 5th example part of it state:

```
#eval double (10 : Int)
-- 100
```

However, the actual evaluation returns 10 as-is. I'm not sure if this was meant to return 100 or 10 (the correct fix depends on the answer to that question), but assuming we really did want 100 there as a way to show how the resolution of Nat and Int are different, then this should be the correct patch.