### PR TITLE
indicate how to type `⟨` and `⟩`

### DIFF
--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -893,7 +893,7 @@ notion of a function type ``α → β`` by allowing ``β`` to depend on
 the Cartesian product ``α × β`` in the same way. Dependent products
 are also called *sigma* types, and you can also write them as
 `Σ a : α, β a`. You can use `⟨a, b⟩` or `Sigma.mk a b` to create a
-dependent pair.  The `⟨` and `⟩` Unicode characters may be typed with
+dependent pair.  The `⟨` and `⟩` characters may be typed with
 `\langle` and `\rangle` or `\<` and `\>`, respectively.
 
 ```lean

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -893,7 +893,8 @@ notion of a function type ``α → β`` by allowing ``β`` to depend on
 the Cartesian product ``α × β`` in the same way. Dependent products
 are also called *sigma* types, and you can also write them as
 `Σ a : α, β a`. You can use `⟨a, b⟩` or `Sigma.mk a b` to create a
-dependent pair.
+dependent pair.  The `⟨` and `⟩` Unicode characters may be typed with
+`\langle` and `\rangle`, respectively.
 
 ```lean
 universe u v

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -894,7 +894,7 @@ the Cartesian product ``α × β`` in the same way. Dependent products
 are also called *sigma* types, and you can also write them as
 `Σ a : α, β a`. You can use `⟨a, b⟩` or `Sigma.mk a b` to create a
 dependent pair.  The `⟨` and `⟩` Unicode characters may be typed with
-`\langle` and `\rangle`, respectively.
+`\langle` and `\rangle` or `\<` and `\>`, respectively.
 
 ```lean
 universe u v


### PR DESCRIPTION
~Can I also confirm that there are no ASCII equivalents (e.g. `<|` and `|>`) to these tokens?  I couldn't find anything in Lean.Parser.Term but I certainly could have missed something.  Thanks!~

edit: found a reference to `\<` and `\>` in the subsequent chapter.