### PR TITLE
Fix typos in tactics.md

### DIFF
--- a/tactics.md
+++ b/tactics.md
@@ -1098,7 +1098,7 @@ example (a b c : Nat) : a + b + c = a + c + b := by
 In the first example above, the first step rewrites ``a + b + c`` to
 ``a + (b + c)``. The next step applies commutativity to the term
 ``b + c``; without specifying the argument, the tactic would instead rewrite
-``a + (b + c)`` to ``(b + c) + a``. Finally, the last step applies
+``a + (b + c)`` to ``a + (c + b)``. Finally, the last step applies
 associativity in the reverse direction, rewriting ``a + (c + b)`` to
 ``a + c + b``. The next two examples instead apply associativity to
 move the parenthesis to the right on both sides, and then switch ``b``


### PR DESCRIPTION
Using `rw [Nat.add_comm b]` should change ``a + (b + c)`` to ``a + (c + b)`` instead.

See: https://live.lean-lang.org/#code=example%20(a%20b%20c%20%3A%20Nat)%20%3A%20a%20%2B%20b%20%2B%20c%20%3D%20a%20%2B%20c%20%2B%20b%20%3A%3D%20by%0A%20%20rw%20%5BNat.add_assoc%2C%20Nat.add_comm%20b%2C%20←%20Nat.add_assoc%5D