### PR TITLE
Fix type_classes examples

### DIFF
--- a/type_classes.md
+++ b/type_classes.md
@@ -105,7 +105,7 @@ def double [Add a] (x : a) : a :=
 -- 20
 
 #eval double (10 : Int)
--- 100
+-- 20
 
 #eval double (7 : Float)
 -- 14.000000


### PR DESCRIPTION
Fixing typo in typeclasses examples

Before
```lean
#eval double (10 : Int)
-- 100
```

After
```lean
#eval double (10 : Int)
-- 20
```