### PR TITLE
Remove duplicated section.

### DIFF
--- a/induction_and_recursion.md
+++ b/induction_and_recursion.md
@@ -598,7 +598,7 @@ def listAdd [Add α] : List α → List α → List α
 
 You are encouraged to experiment with similar examples in the exercises below.
 
-Local recursive declarations
+Local Recursive Declarations
 ---------
 
 You can define local recursive declarations using the `let rec` keyword.
@@ -1430,66 +1430,6 @@ example (h₀ : ∃ x, p x) (h₁ : ∃ y, q y)
   let ⟨x, px⟩ := h₀
   let ⟨y, qy⟩ := h₁
   ⟨x, y, px, qy⟩
-```
-
-Local Recursive Declarations
----------
-
-You can define local recursive declarations using the `let rec` keyword.
-
-```lean
-def replicate (n : Nat) (a : α) : List α :=
-  let rec loop : Nat → List α → List α
-    | 0,   as => as
-    | n+1, as => loop n (a::as)
-  loop n []
-
-#check @replicate.loop
--- {α : Type} → α → Nat → List α → List α
-```
-
-Lean creates an auxiliary declaration for each `let rec`. In the example above,
-it created the declaration `replicate.loop` for the `let rec loop` occurring at `replicate`.
-Note that, Lean "closes" the declaration by adding any local variable occurring in the
-`let rec` declaration as additional parameters. For example, the local variable `a` occurs
-at `let rec loop`.
-
-You can also use `let rec` in tactic mode and for creating proofs by induction.
-
-```lean
-# def replicate (n : Nat) (a : α) : List α :=
-#  let rec loop : Nat → List α → List α
-#    | 0,   as => as
-#    | n+1, as => loop n (a::as)
-#  loop n []
-theorem length_replicate (n : Nat) (a : α) : (replicate n a).length = n := by
-  let rec aux (n : Nat) (as : List α)
-              : (replicate.loop a n as).length = n + as.length := by
-    match n with
-    | 0   => simp [replicate.loop]
-    | n+1 => simp [replicate.loop, aux n, Nat.add_succ, Nat.succ_add]
-  exact aux n []
-```
-
-You can also introduce auxiliary recursive declarations using a `where` clause after your definition.
-Lean converts them into a `let rec`.
-
-```lean
-def replicate (n : Nat) (a : α) : List α :=
-  loop n []
-where
-  loop : Nat → List α → List α
-    | 0,   as => as
-    | n+1, as => loop n (a::as)
-
-theorem length_replicate (n : Nat) (a : α) : (replicate n a).length = n := by
-  exact aux n []
-where
-  aux (n : Nat) (as : List α)
-      : (replicate.loop a n as).length = n + as.length := by
-    match n with
-    | 0   => simp [replicate.loop]
-    | n+1 => simp [replicate.loop, aux n, Nat.add_succ, Nat.succ_add]
 ```
 
 Exercises


### PR DESCRIPTION
There are two instances of Section Local Recursive Declarations in induction_and_recursion.md.
This pull request removes the second one (at the end of the file).