### PR TITLE
Link to Quickstart instead of Setup on title page

### DIFF
--- a/title_page.md
+++ b/title_page.md
@@ -2,8 +2,8 @@
 
 *by Jeremy Avigad, Leonardo de Moura, Soonho Kong and Sebastian Ullrich, with contributions from the Lean Community*
 
-This version of the text assumes you’re using Lean 4. See the [Setting
-Up Lean section](https://lean-lang.org/lean4/doc/setup.html) of
+This version of the text assumes you’re using Lean 4. See the
+[Quickstart section](https://lean-lang.org/lean4/doc/quickstart.html) of
 the [Lean 4 Manual](https://lean-lang.org/lean4/doc/) to install Lean. The first version of this book was
 written for Lean 2, and the Lean 3 version is available
 [here](https://leanprover.github.io/theorem_proving_in_lean/).


### PR DESCRIPTION
As suggested by Shreyas Srinivas on Zulip. _Functional Programming in Lean_ does the same.