### PR TITLE
Fixed typo

### DIFF
--- a/quantifiers_and_equality.md
+++ b/quantifiers_and_equality.md
@@ -594,7 +594,7 @@ example (x y z : Nat) (hxy : x < y) (hyz : y < z) : ∃ w, x < w ∧ w < z :=
 
 Note that ``Exists.intro`` has implicit arguments: Lean has to infer
 the predicate ``p : α → Prop`` in the conclusion ``∃ x, p x``.  This
-is not a trivial affair. For example, if we have have
+is not a trivial affair. For example, if we have
 ``hg : g 0 0 = 0`` and write ``Exists.intro 0 hg``, there are many possible values
 for the predicate ``p``, corresponding to the theorems ``∃ x, g x x = x``,
 ``∃ x, g x x = 0``, ``∃ x, g x 0 = x``, etc. Lean uses the


### PR DESCRIPTION
There is a typo in the `quantifiers_and_equality.md` file 'have have' which should be a single 'have'. Fixed that.