### PR TITLE
doc: clarify how Lean supports constructive logic

### DIFF
--- a/axioms_and_computation.md
+++ b/axioms_and_computation.md
@@ -103,9 +103,9 @@ namespace or used lemmas within it. Technically, it is still possible to
 build alternative tactics for constructive logic outside the core
 library and use them alongside the constructive tactics from the core.
 However, the developers of Lean's core library currently do not want to
-implement these tactics themselves, nor do they accept any changes that
+implement these tactics themselves, nor do they accept changes that
 attempt to modify the tactics in the core to avoid using classical
-reasoning, regardless of how simple the change may be.
+reasoning.
 
 Computationally, the purest part of dependent type theory avoids the
 use of ``Prop`` entirely. Inductive types and dependent function types

--- a/axioms_and_computation.md
+++ b/axioms_and_computation.md
@@ -95,10 +95,17 @@ computational interpretation. From a *classical* point of view, it is
 more fruitful to maintain a separation of concerns: we can use one
 language and body of methods to write computer programs, while
 maintaining the freedom to use nonconstructive theories and methods
-to reason about them. Lean is designed to support both of these
-approaches. Core parts of the library are developed constructively,
-but the system also provides support for carrying out classical
-mathematical reasoning.
+to reason about them.
+
+Be aware that some tactics in Lean's core library use classical
+reasoning by default, even if a user has not opened the `Classical`
+namespace or used lemmas within it. Technically, it is still possible to
+build alternative tactics for constructive logic outside the core
+library and use them alongside the constructive tactics from the core.
+However, the developers of Lean's core library currently do not want to
+implement these tactics themselves, nor do they accept any changes that
+attempt to modify the tactics in the core to avoid using classical
+reasoning, regardless of how simple the change may be.
 
 Computationally, the purest part of dependent type theory avoids the
 use of ``Prop`` entirely. Inductive types and dependent function types

--- a/introduction.md
+++ b/introduction.md
@@ -61,6 +61,10 @@ To install Lean in your computer consider using the [Quickstart](https://github.
 
 This tutorial describes the current version of Lean, known as Lean 4.
 
+You may want to reconsider your decision to learn Lean if you plan to use it for
+projects based on constructive logic. See [Section Historical and Philosophical
+Context](./axioms_and_computation.md#historical-and-philosophical-context).
+
 About this Book
 ---------------
 

--- a/introduction.md
+++ b/introduction.md
@@ -62,7 +62,8 @@ To install Lean in your computer consider using the [Quickstart](https://github.
 This tutorial describes the current version of Lean, known as Lean 4.
 
 You may want to reconsider your decision to learn Lean if you plan to use it for
-projects based on constructive logic. See [Section Historical and Philosophical
+projects based on constructive logic. See the fourth paragraph of [Section
+Historical and Philosophical
 Context](./axioms_and_computation.md#historical-and-philosophical-context).
 
 About this Book


### PR DESCRIPTION
The paragraph I added to Section 'Historical and Philosophical Context'
explains how Lean core [supports constructive logic][0], whether the
Lean core team will provide tactics for constructive logic or [accept
them from contributors][1], and whether a user can [develop them by
oneself][2] [outside the core][3].

I also added a cautionary note for constructivists to Chapter
'Introduction.'

[0]:
https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/Movement.20from.20Std.20to.20Init/near/430339840
[1]:
https://leanprover.zulipchat.com/#narrow/stream/348111-std4/topic/How.20classical.20is.20std4.3F/near/383780177
[2]:
https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/constructive.20tactic.20mode.20in.20lean/near/431685357
[3]:
https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/constructive.20tactic.20mode.20in.20lean/near/431714863

Co-authored-by: Mario Carneiro <di.gama@gmail.com>
Co-authored-by: Henrik Böving <hargonix@gmail.com>
Co-authored-by: Kim Morrison <kim@tqft.net>