### PR TITLE
Small fixes

### DIFF
--- a/axioms_and_computation.md
+++ b/axioms_and_computation.md
@@ -341,7 +341,7 @@ In a sense, however, a cast does not change the meaning of an
 expression. Rather, it is a mechanism to reason about the expression's
 type. Given an appropriate semantics, it then makes sense to reduce
 terms in ways that preserve their meaning, ignoring the intermediate
-bookkeeping needed to make the reductions type correct. In that case,
+bookkeeping needed to make the reductions type-correct. In that case,
 adding new axioms in ``Prop`` does not matter; by proof irrelevance,
 an expression in ``Prop`` carries no information, and can be safely
 ignored by the reduction procedures.

--- a/conv.md
+++ b/conv.md
@@ -35,7 +35,8 @@ example (a b c : Nat) : a * (b * c) = a * (c * b) := by
 
 The above snippet shows three navigation commands:
 
-- `lhs` navigates to the left hand side of a relation (here equality), there is also a `rhs` navigating to the right hand side.
+- `lhs` navigates to the left-hand side of a relation (equality, in this case).
+There is also a `rhs` to navigate to the right-hand side.
 - `congr` creates as many targets as there are (nondependent and explicit) arguments to the current head function
   (here the head function is multiplication).
 - `rfl` closes target using reflexivity.

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -18,7 +18,7 @@ numbers. For those who like precise definitions, a Lean natural number
 is an arbitrary-precision unsigned integer.
 
 Here are some examples of how you can declare objects in Lean and
-check their types.
+check their types:
 
 ```lean
 /- Define some constants. -/
@@ -145,8 +145,7 @@ its two components.
 One way in which Lean's dependent type theory extends simple type
 theory is that types themselves --- entities like ``Nat`` and ``Bool``
 --- are first-class citizens, which is to say that they themselves are
-objects. For that to be the case, each of them also has to have a
-type.
+objects. For that to be the case, each must also have a type.
 
 ```lean
 #check Nat               -- Type
@@ -256,15 +255,15 @@ type signature of the function ``List``:
 ```
 
 Here ``u`` is a variable ranging over type levels. The output of the
-``#check`` command means that whenever ``α`` has type ``Type n``,
-``List α`` also has type ``Type n``. The function ``Prod`` is
+``#check List`` command means that whenever ``α`` has type ``Type u``,
+``List α`` also has type ``Type u``. The function ``Prod`` is
 similarly polymorphic:
 
 ```lean
 #check Prod    -- Prod.{u, v} (α : Type u) (β : Type v) : Type (max u v)
 ```
 
-To define polymorphic constants, Lean allows you to
+To define polymorphic constants, Lean lets you
 declare universe variables explicitly using the `universe` command:
 
 ```lean
@@ -440,9 +439,8 @@ def double (x : Nat) : Nat :=
 
 This might look more familiar to you if you know how functions work in
 other programming languages. The name `double` is defined as a
-function that takes an input parameter `x` of type `Nat`, where the
-result of the call is `x + x`, so it is returning type `Nat`. You
-can then invoke this function using:
+function that takes an input parameter `x` of type `Nat` and returns `x + x`, so its return type is `Nat`.
+You can then invoke this function using:
 
 ```lean
 # def double (x : Nat) : Nat :=
@@ -450,7 +448,7 @@ can then invoke this function using:
 #eval double 3    -- 6
 ```
 
-In this case you can think of `def` as a kind of named `lambda`.
+You can think of `def` as a kind of named `lambda`.
 The following yields the same result:
 
 ```lean
@@ -482,31 +480,33 @@ So `def` can also be used to simply name a value like this:
 def pi := 3.141592654
 ```
 
-`def` can take multiple input parameters.  Let's create one
+`def` can take multiple input parameters.  Let's define a function
 that adds two natural numbers:
 
 ```lean
-def add (x y : Nat) :=
+def add (x : Nat) (y : Nat) :=
   x + y
 
 #eval add 3 2               -- 5
 ```
 
-The parameter list can be separated like this:
+For convenience, the parameter list can be abbreviated like this (though the resulting function will have the same type):
 
 ```lean
 # def double (x : Nat) : Nat :=
 #  x + x
-def add (x : Nat) (y : Nat) :=
+def add (x y : Nat) :=
   x + y
 
 #eval add (double 3) (7 + 9)  -- 22
 ```
 
-Notice here we called the `double` function to create the first
+Notice that the example uses the `double` function to create the first
 parameter to `add`.
 
-You can use other more interesting expressions inside a `def`:
+<!-- a quick note about currying would be in order here -->
+
+You can use more interesting expressions inside a `def`:
 
 ```lean
 def greater (x y : Nat) :=
@@ -516,8 +516,8 @@ def greater (x y : Nat) :=
 
 You can probably guess what this one will do.
 
-You can also define a function that takes another function as input.
-The following calls a given function twice passing the output of the
+You can also define functions that take other functions as input (known as "higher-order functions").
+The following calls a given function twice, passing the output of the
 first invocation to the second:
 
 ```lean
@@ -529,26 +529,26 @@ def doTwice (f : Nat → Nat) (x : Nat) : Nat :=
 #eval doTwice double 2   -- 8
 ```
 
-Now to get a bit more abstract, you can also specify arguments that
-are like type parameters:
+Getting a bit more abstract, you can also specify arguments that
+are like type parameters, like `(α β γ : Type)` here:
 
 ```lean
 def compose (α β γ : Type) (g : β → γ) (f : α → β) (x : α) : γ :=
   g (f x)
 ```
 
-This means `compose` is a function that takes any two functions as input
-arguments, so long as those functions each take only one input.
-The type algebra `β → γ` and `α → β` means it is a requirement
+This defines `compose` as a function that takes three type arguments (`α β γ : Type`) and two other functions,
+locally named `f` and `g`. Furthermore,
+the type constraints `β → γ` and `α → β` require
 that the type of the output of the second function must match the
 type of the input to the first function - which makes sense, otherwise
 the two functions would not be composable.
 
-`compose` also takes a 3rd argument of type `α` which
-it uses to invoke the second function (locally named `f`) and it
-passes the result of that function (which is type `β`) as input to the
-first function (locally named `g`).  The first function returns a type
-`γ` so that is also the return type of the `compose` function.
+`compose` also takes a last argument of type `α`, which
+it uses to invoke the second function (`f`). 
+The result of that function, of type `β`, is passed as the input to the
+first function (`g`).  The first function returns a result of type
+`γ`, so that is also the return type of the `compose` function.
 
 `compose` is also very general in that it works over any type
 `α β γ`.  This means `compose` can compose just about any 2 functions
@@ -565,6 +565,11 @@ def square (x : Nat) : Nat :=
 
 #eval compose Nat Nat Nat double square 3  -- 18
 ```
+
+Lean has syntax to make the three type parameters (`α β γ`) implicit,
+so that they don't have to be explicitly included each time that `compose` is called ---
+see the (Additional Conveniences)[https://lean-lang.org/functional_programming_in_lean/getting-to-know/conveniences.html]
+section of [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/title.html).
 
 Local Definitions
 -----------------
@@ -738,7 +743,7 @@ identifier you declare has a full name with prefix "``Foo.``". Within
 the namespace, you can refer to identifiers by their shorter names,
 but once you end the namespace, you have to use the longer names.
 Unlike `section`, namespaces require a name. There is only one
-anonymous namespace at the root level.
+anonymous namespace: the one at the root level.
 
 The ``open`` command brings the shorter names into the current
 context. Often, when you import a module, you will want to open one or

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -515,7 +515,7 @@ def greater (x y : Nat) :=
 
 You can probably guess what this one will do.
 
-You can also define functions that take other functions as input (known as "higher-order functions").
+You can also define functions that take other functions as input (known as *higher-order functions*).
 The following calls a given function twice, passing the output of the
 first invocation to the second:
 
@@ -528,15 +528,15 @@ def doTwice (f : Nat → Nat) (x : Nat) : Nat :=
 #eval doTwice double 2   -- 8
 ```
 
-Getting a bit more abstract, you can also specify arguments that
-are like type parameters, like `(α β γ : Type)` here:
+Getting a bit more abstract, you can also specify arguments that work as type parameters,
+such as `(α β γ : Type)` here:
 
 ```lean
 def compose (α β γ : Type) (g : β → γ) (f : α → β) (x : α) : γ :=
   g (f x)
 ```
 
-This defines `compose` as a function that takes three type arguments (`α β γ : Type`) and two other functions,
+This defines `compose` as a function that takes three type arguments (`α β γ : Type`) and two other functions as arguments,
 locally named `f` and `g`. Furthermore,
 the type constraints `β → γ` and `α → β` require
 that the type of the output of the second function must match the

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -272,7 +272,7 @@ def F (α : Type u) : Type u := Prod α α
 #check F    -- Type u → Type u
 ```
 
-You can avoid the universe command by providing the universe parameters when defining F.
+You can avoid the `universe` command by providing the universe parameters when defining `F`:
 
 ```lean
 def F.{u} (α : Type u) : Type u := Prod α α
@@ -283,8 +283,8 @@ def F.{u} (α : Type u) : Type u := Prod α α
 
 ## Function Abstraction and Evaluation
 
-Lean provides a `fun` (or `λ`) keyword to create a function
-from an expression as follows:
+Lean uses the keyword `fun` (or `λ`, entered as ``\lambda``) to create a function
+from an expression, as follows:
 
 ```lean
 #check fun (x : Nat) => x + 5   -- Nat → Nat
@@ -335,12 +335,12 @@ Think about what these expressions mean. The expression
 ``fun x : Nat => x`` denotes the identity function on ``Nat``, the
 expression ``fun x : Nat => true`` denotes the constant function that
 always returns ``true``, and ``fun x : Nat => g (f x)`` denotes the
-composition of ``f`` and ``g``.  You can, in general, leave off the
+composition of ``f`` and ``g``.  You can, in general, skip the
 type annotation and let Lean infer it for you.  So, for example, you
 can write ``fun x => g (f x)`` instead of ``fun x : Nat => g (f x)``.
 
-You can pass functions as parameters and by giving them names `f`
-and `g` you can then use those functions in the implementation:
+You can pass functions as parameters and use them in the implementation,
+as with `f` and `g` below:
 
 ```lean
 #check fun (g : String → Bool) (f : Nat → String) (x : Nat) => g (f x)
@@ -352,11 +352,11 @@ You can also pass types as parameters:
 ```lean
 #check fun (α β γ : Type) (g : β → γ) (f : α → β) (x : α) => g (f x)
 ```
-The last expression, for example, denotes the function that takes
+This last expression, for example, denotes the function that takes
 three types, ``α``, ``β``, and ``γ``, and two functions, ``g : β → γ``
 and ``f : α → β``, and returns the composition of ``g`` and ``f``.
 (Making sense of the type of this function requires an understanding
-of dependent products, which will be explained below.)
+of *dependent products*, which will be explained below.)
 
 The general form of a lambda expression is ``fun x : α => t``, where
 the variable ``x`` is a "bound variable": it is really a placeholder,
@@ -614,7 +614,7 @@ second expression, ``a`` is a variable, and the expression
 The ``let`` construct is a stronger means of abbreviation, and there
 are expressions of the form ``let a := t1; t2`` that cannot be
 expressed as ``(fun a => t2) t1``. As an exercise, try to understand
-why the definition of ``foo`` below type checks, but the definition of
+why the definition of ``foo`` below type-checks, but the definition of
 ``bar`` does not.
 
 ```lean
@@ -738,12 +738,13 @@ open Foo
 #check Foo.fa
 ```
 
-When you declare that you are working in the namespace ``Foo``, every
-identifier you declare has a full name with prefix "``Foo.``". Within
-the namespace, you can refer to identifiers by their shorter names,
-but once you end the namespace, you have to use the longer names.
-Unlike `section`, namespaces require a name. There is only one
-anonymous namespace: the one at the root level.
+Inside the scope of the namespace ``Foo``, every
+identifier you declare will be given a full name with prefix "``Foo.``".
+Within the namespace, you can use their shorter names,
+but once you end the namespace, you must use the longer, *fully qualified* names.
+
+Unlike `section`, namespaces require a name. (There is only one
+anonymous namespace: the one at the root level.)
 
 The ``open`` command brings the shorter names into the current
 context. Often, when you import a module, you will want to open one or
@@ -880,7 +881,7 @@ depend on ``a``, ``(a : α) → β`` is no different from the type
 ``α → β``.  Indeed, in dependent type theory (and in Lean), ``α → β``
 is just notation for ``(a : α) → β`` when ``β`` does not depend on ``a``.
 
-Returning to the example of lists, you can use the command `#check` to
+Returning to the example of lists, you can use `#check` to
 inspect the type of the following `List` functions.  The ``@`` symbol
 and the difference between the round and curly braces will be
 explained momentarily.

--- a/dependent_type_theory.md
+++ b/dependent_type_theory.md
@@ -1,9 +1,9 @@
 Dependent Type Theory
 =====================
 
-Dependent type theory is a powerful and expressive language, allowing
+*Dependent type theory* is a powerful and expressive language, allowing
 you to express complex mathematical assertions, write complex hardware
-and software specifications, and reason about both of these in a
+and software specifications, and reason about all of these in a
 natural and uniform way. Lean is based on a version of dependent type
 theory known as the *Calculus of Constructions*, with a countable
 hierarchy of non-cumulative universes and inductive types. By the end
@@ -14,8 +14,8 @@ of this chapter, you will understand much of what this means.
 "Type theory" gets its name from the fact that every expression has an
 associated *type*. For example, in a given context, ``x + 0`` may
 denote a natural number and ``f`` may denote a function on the natural
-numbers. For those who like precise definitions, a Lean natural number
-is an arbitrary-precision unsigned integer.
+numbers. (For those who like precise definitions, a Lean natural number
+is an arbitrary-precision unsigned integer.)
 
 Here are some examples of how you can declare objects in Lean and
 check their types:
@@ -55,14 +55,12 @@ in many programming languages.
 The ``def`` keyword declares new constant symbols into the
 working environment. In the example above, `def m : Nat := 1`
 defines a new constant `m` of type `Nat` whose value is `1`.
-The ``#check`` command asks Lean to report their
-types; in Lean, auxiliary commands that query the system for
-information typically begin with the hash (#) symbol.
-The `#eval` command asks Lean to evaluate the given expression.
-You should try
-declaring some constants and type checking some expressions on your
-own. Declaring new objects in this manner is a good way to experiment
-with the system.
+
+In Lean, auxiliary commands that query the system for information typically begin with the hash (#) symbol.
+The ``#check`` command asks Lean to report the type of a given expression
+types; the `#eval` command asks Lean to evaluate the given expression.
+Try declaring some constants and type checking some expressions on your
+own; this is a good way to experiment with the system.
 
 What makes simple type theory powerful is that you can build new types
 out of others. For example, if ``a`` and ``b`` are types, ``a -> b``
@@ -223,8 +221,8 @@ hierarchy of types:
 Think of ``Type 0`` as a universe of "small" or "ordinary" types.
 ``Type 1`` is then a larger universe of types, which contains ``Type
 0`` as an element, and ``Type 2`` is an even larger universe of types,
-which contains ``Type 1`` as an element. The list is indefinite, so
-that there is a ``Type n`` for every natural number ``n``. ``Type`` is
+which contains ``Type 1`` as an element. The list is infinite:
+there is a ``Type n`` for every natural number ``n``. ``Type`` is
 an abbreviation for ``Type 0``:
 
 ```lean
@@ -490,7 +488,7 @@ def add (x : Nat) (y : Nat) :=
 #eval add 3 2               -- 5
 ```
 
-For convenience, the parameter list can be abbreviated like this (though the resulting function will have the same type):
+For convenience, the parameter list can be abbreviated as follows:
 
 ```lean
 # def double (x : Nat) : Nat :=
@@ -500,11 +498,12 @@ def add (x y : Nat) :=
 
 #eval add (double 3) (7 + 9)  -- 22
 ```
+The resulting function will display a different *signature*, but the function itself will have the same type as before.
 
 Notice that the example uses the `double` function to create the first
 parameter to `add`.
 
-<!-- a quick note about currying would be in order here -->
+<!-- a quick note about currying would be in order here, and perhaps a definition of "signature" -->
 
 You can use more interesting expressions inside a `def`:
 
@@ -568,13 +567,14 @@ def square (x : Nat) : Nat :=
 
 Lean has syntax to make the three type parameters (`α β γ`) implicit,
 so that they don't have to be explicitly included each time that `compose` is called ---
-see the (Additional Conveniences)[https://lean-lang.org/functional_programming_in_lean/getting-to-know/conveniences.html]
-section of [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/title.html).
+see the [Implicit Arguments](#Implicit-Arguments) section below.
+<!-- See also the [Additional Conveniences](https://lean-lang.org/functional_programming_in_lean/getting-to-know/conveniences.html)
+section of [Functional Programming in Lean](https://lean-lang.org/functional_programming_in_lean/title.html). -->
 
 Local Definitions
 -----------------
 
-Lean also allows you to introduce "local" definitions using the
+You can introduce "local" definitions in Lean using the
 ``let`` keyword. The expression ``let a := t1; t2`` is
 definitionally equal to the result of replacing every occurrence of
 ``a`` in ``t2`` by ``t1``.
@@ -610,7 +610,7 @@ similar to the meaning of ``(fun a => t2) t1``, but the two are not
 the same. In the first expression, you should think of every instance
 of ``a`` in ``t2`` as a syntactic abbreviation for ``t1``. In the
 second expression, ``a`` is a variable, and the expression
-``fun a => t2`` has to make sense independently of the value of ``a``.
+``fun a => t2`` must make sense independently of the value of ``a``.
 The ``let`` construct is a stronger means of abbreviation, and there
 are expressions of the form ``let a := t1; t2`` that cannot be
 expressed as ``(fun a => t2) t1``. As an exercise, try to understand
@@ -637,8 +637,8 @@ def doThrice (α : Type) (h : α → α) (x : α) : α :=
   h (h (h x))
 ```
 
-Lean provides you with the ``variable`` command to make such
-declarations look more compact:
+Lean provides the ``variable`` command to make such
+declarations more compact:
 
 ```lean
 variable (α β γ : Type)
@@ -705,7 +705,7 @@ which allows you to declare new variables incrementally.
 
 # Namespaces
 
-Lean provides you with the ability to group definitions into nested,
+Lean lets you group definitions into nested,
 hierarchical *namespaces*:
 
 ```lean
@@ -940,7 +940,7 @@ Suppose we have an implementation of lists as:
 #check Lst.append   -- Lst.append.{u} (α : Type u) (as bs : Lst α) : Lst α
 ```
 
-Then, you can construct lists of `Nat` as follows.
+Then, you can construct lists of `Nat` as follows:
 
 ```lean
 # universe u
@@ -1069,7 +1069,7 @@ One can always specify the type ``T`` of an expression ``e`` by
 writing ``(e : T)``. This instructs Lean's elaborator to use the value
 ``T`` as the type of ``e`` when trying to resolve implicit
 arguments. In the second pair of examples below, this mechanism is
-used to specify the desired types of the expressions ``id`` and
+used to specify the desired types for the expressions ``id`` and
 ``List.nil``:
 
 ```lean
@@ -1081,10 +1081,10 @@ used to specify the desired types of the expressions ``id`` and
 ```
 
 Numerals are overloaded in Lean, but when the type of a numeral cannot
-be inferred, Lean assumes, by default, that it is a natural number. So
-the expressions in the first two ``#check`` commands below are
-elaborated in the same way, whereas the third ``#check`` command
-interprets ``2`` as an integer.
+be inferred, Lean assumes, by default, that it is a natural number. Thus,
+the expressions in the first two ``#check`` commands below are both
+elaborated as `Nat`, whereas the third ``#check`` command
+interprets ``2`` as an `Int`. <!-- difference between Nat and Int has not been explained yet. -->
 
 ```lean
 #check 2            -- Nat
@@ -1107,6 +1107,7 @@ made explicit.
 #check @id Bool true -- Bool
 ```
 
-Notice that now the first ``#check`` command gives the type of the
-identifier, ``id``, without inserting any placeholders. Moreover, the
-output indicates that the first argument is implicit.
+Notice that the ``#check @id`` command now gives the full type of the
+identifier, ``id``, without having to insert any placeholders. Moreover, the
+curly brackets in the
+output indicats that the first argument, `α`, is implicit.

--- a/induction_and_recursion.md
+++ b/induction_and_recursion.md
@@ -688,7 +688,7 @@ if ``x`` has no predecessors, it is accessible. Given any type ``α``,
 we should be able to assign a value to each accessible element of
 ``α``, recursively, by assigning values to all its predecessors first.
 
-The statement that ``r`` is well founded, denoted ``WellFounded r``,
+The statement that ``r`` is well-founded, denoted ``WellFounded r``,
 is exactly the statement that every element of the type is
 accessible. By the above considerations, if ``r`` is a well-founded
 relation on a type ``α``, we should have a principle of well-founded
@@ -707,7 +707,7 @@ noncomputable def f {α : Sort u}
 
 There is a long cast of characters here, but the first block we have
 already seen: the type, ``α``, the relation, ``r``, and the
-assumption, ``h``, that ``r`` is well founded. The variable ``C``
+assumption, ``h``, that ``r`` is well-founded. The variable ``C``
 represents the motive of the recursive definition: for each element
 ``x : α``, we would like to construct an element of ``C x``. The
 function ``F`` provides the inductive recipe for doing that: it tells
@@ -715,7 +715,7 @@ us how to construct an element ``C x``, given elements of ``C y`` for
 each predecessor ``y`` of ``x``.
 
 Note that ``WellFounded.fix`` works equally well as an induction
-principle. It says that if ``≺`` is well founded and you want to prove
+principle. It says that if ``≺`` is well-founded and you want to prove
 ``∀ x, C x``, it suffices to show that for an arbitrary ``x``, if we
 have ``∀ y ≺ x, C y``, then we have ``C x``.
 
@@ -810,7 +810,7 @@ def natToBin : Nat → List Nat
 ```
 
 As a final example, we observe that Ackermann's function can be
-defined directly, because it is justified by the well foundedness of
+defined directly, because it is justified by the well-foundedness of
 the lexicographic order on the natural numbers. The `termination_by` clause
 instructs Lean to use a lexicographic order. This clause is actually mapping
 the function arguments to elements of type `Nat × Nat`. Then, Lean uses typeclass

--- a/interacting_with_lean.md
+++ b/interacting_with_lean.md
@@ -17,8 +17,8 @@ Importing Files
 ---------------
 
 The goal of Lean's front end is to interpret user input, construct
-formal expressions, and check that they are well formed and type
-correct. Lean also supports the use of various editors, which provide
+formal expressions, and check that they are well-formed and type-correct.
+Lean also supports the use of various editors, which provide
 continuous checking and feedback. More information can be found on the
 Lean [documentation pages](https://lean-lang.org/documentation/).
 
@@ -542,7 +542,7 @@ The new notation is preferred to the binary notation since the latter,
 before chaining, would stop parsing after `1 + 2`.  If there are
 multiple notations accepting the same longest parse, the choice will
 be delayed until elaboration, which will fail unless exactly one
-overload is type correct.
+overload is type-correct.
 
 Coercions
 ---------

--- a/introduction.md
+++ b/introduction.md
@@ -13,13 +13,13 @@ as to their correctness becomes a form of theorem proving. Conversely, the proof
 lengthy computation, in which case verifying the truth of the theorem requires verifying that the computation does what
 it is supposed to do.
 
-The gold standard for supporting a mathematical claim is to provide a proof, and twentieth-century developments in logic
-show most if not all conventional proof methods can be reduced to a small set of axioms and rules in any of a number of
+The gold standard for supporting a mathematical claim is to provide a proof. Twentieth-century developments in logic
+show that most if not all conventional proof methods can be reduced to a small set of axioms and rules in any of a number of
 foundational systems. With this reduction, there are two ways that a computer can help establish a claim: it can help
 find a proof in the first place, and it can help verify that a purported proof is correct.
 
-*Automated theorem proving* focuses on the "finding" aspect. Resolution theorem provers, tableau theorem provers, fast
-satisfiability solvers, and so on provide means of establishing the validity of formulas in propositional and
+*Automated theorem proving* focuses on the "finding" aspect. Resolution theorem provers, tableau theorem provers
+and satisfiability solvers, for example, provide means of establishing the validity of formulas in propositional and
 first-order logic. Other systems provide search procedures and decision procedures for specific languages and domains,
 such as linear or nonlinear expressions over the integers or the real numbers. Architectures like SMT ("satisfiability
 modulo theories") combine domain-general search methods with domain-specific procedures. Computer algebra systems and

--- a/propositions_and_proofs.md
+++ b/propositions_and_proofs.md
@@ -2,7 +2,7 @@ Propositions and Proofs
 =======================
 
 By now, you have seen some ways of defining objects and functions in
-Lean. In this chapter, we will begin to explain how to write
+Lean. In this chapter, we begin to explain how to write
 mathematical assertions and proofs in the language of dependent type
 theory as well.
 
@@ -13,10 +13,11 @@ One strategy for proving assertions about objects defined in the
 language of dependent type theory is to layer an assertion language
 and a proof language on top of the definition language. But there is
 no reason to multiply languages in this way: dependent type theory is
-flexible and expressive, and there is no reason we cannot represent
+flexible and expressive, and it turns out that there is no reason we cannot represent
 assertions and proofs in the same general framework.
 
-For example, we could introduce a new type, ``Prop``, to represent
+As an example of layering an assertion language on top,
+we could introduce a new type, ``Prop``, to represent
 propositions, and introduce constructors to build new propositions
 from others.
 
@@ -77,7 +78,7 @@ We could render this as follows:
 axiom implies_intro : (p q : Prop) → (Proof p → Proof q) → Proof (Implies p q)
 ```
 
-This approach would provide us with a reasonable way of building assertions and proofs.
+This approach would give us a reasonable way of building assertions and proofs.
 Determining that an expression ``t`` is a correct proof of assertion ``p`` would then
 simply be a matter of checking that ``t`` has type ``Proof p``.
 
@@ -115,9 +116,9 @@ proposition ``p`` represents a sort of data type, namely, a
 specification of the type of data that constitutes a proof. A proof of
 ``p`` is then simply an object ``t : p`` of the right type.
 
-Those not inclined to this ideology can view it, rather, as a simple
+Those not inclined to this philosophy can view it, rather, as a simple
 coding trick. To each proposition ``p`` we associate a type that is
-empty if ``p`` is false and has a single element, say ``*``, if ``p``
+empty if ``p`` is false, and has a single element, say ``*``, if ``p``
 is true. In the latter case, let us say that (the type associated
 with) ``p`` is *inhabited*. It just so happens that the rules for
 function application and abstraction can conveniently help us keep
@@ -136,7 +137,7 @@ that even though we can treat proofs ``t : p`` as ordinary objects in
 the language of dependent type theory, they carry no information
 beyond the fact that ``p`` is true.
 
-The two ways we have suggested thinking about the
+The two ways we have suggested for thinking about the
 propositions-as-types paradigm differ in a fundamental way. From the
 constructive point of view, proofs are abstract mathematical objects
 that are *denoted* by suitable expressions in dependent type
@@ -160,7 +161,8 @@ In any case, all that really matters is the bottom line. To formally
 express a mathematical assertion in the language of dependent type
 theory, we need to exhibit a term ``p : Prop``. To *prove* that
 assertion, we need to exhibit a term ``t : p``. Lean's task, as a
-proof assistant, is to help us to construct such a term, ``t``, and to
+proof assistant, is to help us to construct such a term ``t``, and to
+    - construct such a type ``t`` ??? ---
 verify that it is well-formed and has the correct type.
 
 Working with Propositions as Types
@@ -191,7 +193,7 @@ true.
 Note that the ``theorem`` command is really a version of the
 ``def`` command: under the propositions and types
 correspondence, proving the theorem ``p → q → p`` is really the same
-as defining an element of the associated type. To the kernel type
+as defining an element of the associated type. To the Lean kernel type
 checker, there is no difference between the two.
 
 There are a few pragmatic differences between definitions and
@@ -202,7 +204,7 @@ theorem is complete, typically we only need to know that the proof
 exists; it doesn't matter what the proof is. In light of that fact,
 Lean tags proofs as *irreducible*, which serves as a hint to the
 parser (more precisely, the *elaborator*) that there is generally no
-need to unfold it when processing a file. In fact, Lean is generally
+need to unfold them when processing a file. In fact, Lean is generally
 able to process and check proofs in parallel, since assessing the
 correctness of one proof does not require knowing the details of
 another.
@@ -260,10 +262,9 @@ axiom hp : p
 theorem t2 : q → p := t1 hp
 ```
 
-Here, the ``axiom`` declaration postulates the existence of an
-element of the given type and may compromise logical consistency. For
-example, we can use it to postulate the empty type `False` has an
-element.
+The ``axiom`` declaration postulates the existence of an
+element of the given type, and may compromise logical consistency. For
+example, it can postulate that the empty type `False` has an element:
 
 ```lean
 axiom unsound : False

--- a/propositions_and_proofs.md
+++ b/propositions_and_proofs.md
@@ -16,7 +16,7 @@ no reason to multiply languages in this way: dependent type theory is
 flexible and expressive, and it turns out that there is no reason we cannot represent
 assertions and proofs in the same general framework.
 
-As an example of layering an assertion language on top,
+As an example of layering languages on top,
 we could introduce a new type, ``Prop``, to represent
 propositions, and introduce constructors to build new propositions
 from others.
@@ -52,7 +52,7 @@ variable (p q : Prop)
 
 In addition to axioms, however, we would also need rules to build new
 proofs from old ones. For example, in many proof systems for
-propositional logic, we have the rule of modus ponens:
+propositional logic, we have the rule of *modus ponens*:
 
 > From a proof of ``Implies p q`` and a proof of ``p``, we obtain a proof of ``q``.
 
@@ -78,7 +78,7 @@ We could render this as follows:
 axiom implies_intro : (p q : Prop) → (Proof p → Proof q) → Proof (Implies p q)
 ```
 
-This approach would give us a reasonable way of building assertions and proofs.
+This would give us a reasonable way of building assertions and proofs.
 Determining that an expression ``t`` is a correct proof of assertion ``p`` would then
 simply be a matter of checking that ``t`` has type ``Proof p``.
 
@@ -93,7 +93,7 @@ show that we can pass back and forth between ``Implies p q`` and
 ``p → q``. In other words, implication between propositions ``p`` and ``q``
 corresponds to having a function that takes any element of ``p`` to an
 element of ``q``. As a result, the introduction of the connective
-``Implies`` is entirely redundant: we can use the usual function space
+``Implies`` is entirely redundant: we can use the function space
 constructor ``p → q`` from dependent type theory as our notion of
 implication.
 
@@ -107,7 +107,7 @@ syntactic sugar for ``Sort 0``, the very bottom of the type hierarchy
 described in the last chapter. Moreover, ``Type u`` is also just
 syntactic sugar for ``Sort (u+1)``. ``Prop`` has some special
 features, but like the other type universes, it is closed under the
-arrow constructor: if we have ``p q : Prop``, then ``p → q : Prop``.
+arrow constructor: if ``p q : Prop``, then ``p → q : Prop``.
 
 There are at least two ways of thinking about propositions as
 types. To some who take a constructive view of logic and mathematics,
@@ -151,19 +151,22 @@ proposition in question is true. In other words, the expressions
 In the exposition below, we will slip back and forth between these two
 ways of talking, at times saying that an expression "constructs" or
 "produces" or "returns" a proof of a proposition, and at other times
-simply saying that it "is" such a proof. This is similar to the way
-that computer scientists occasionally blur the distinction between
+simply saying that it "is" such a proof. This is similar to how
+computer scientists occasionally blur the distinction between
 syntax and semantics by saying, at times, that a program "computes" a
 certain function, and at other times speaking as though the program
 "is" the function in question.
 
-In any case, all that really matters is the bottom line. To formally
+In any case, all that really matters is the bottom line: To formally
 express a mathematical assertion in the language of dependent type
 theory, we need to exhibit a term ``p : Prop``. To *prove* that
-assertion, we need to exhibit a term ``t : p``. Lean's task, as a
-proof assistant, is to help us to construct such a term ``t``, and to
-    - construct such a type ``t`` ??? ---
+assertion, we need to exhibit a term ``t : p`` that has `p` as its type.
+Lean's task, as a proof assistant, is to help us to construct such a term ``t``, and to
 verify that it is well-formed and has the correct type.
+
+<!-- Add a side-node for proofs-as-programs correspondence?
+ From Wikipedia: "a proof is a program, and the formula it proves is the type for the program"
+-->
 
 Working with Propositions as Types
 ----------------------------------
@@ -297,7 +300,7 @@ theorem t1 : ∀ {p q : Prop}, p → q → p :=
 ```
 
 If ``p`` and ``q`` have been declared as variables, Lean will
-generalize them for us automatically:
+generalize them automatically:
 
 ```lean
 variable {p q : Prop}

--- a/tactics.md
+++ b/tactics.md
@@ -61,7 +61,9 @@ theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
      exact hp
 ```
 
-(We often put the ``by`` keyword on the preceding line.) 
+(We often put the ``by`` keyword on the preceding line.)
+
+<!-- Say someting about indentation sensitivity? -->
 
 <!-- repeating the proof is a bit wasteful here.
 
@@ -155,7 +157,7 @@ theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
   exact And.intro hq hp
 ```
 
-Unsurprisingly, it produces exactly the same proof term.
+Unsurprisingly, it produces exactly the same proof term:
 
 ```lean
 # theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
@@ -173,11 +175,13 @@ theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
 
 Tactics that may produce multiple subgoals often *tag* them. For
 example, the tactic ``apply And.intro`` tagged the first subgoal as
-``left``, and the second as ``right``. In the case of the ``apply``
-tactic, the tags are inferred from the parameters' names used in the
-``And.intro`` declaration. You can structure your tactics using the
+``left``, and the second as ``right``. In this ``apply`` tactic invocation,
+the tags are inferred from the parameters' names used in the
+``And.intro`` declaration.
+
+You can structure your tactics using the
 notation ``case <tag> => <tactics>``. The following is a structured
-version of our first tactic proof in this chapter.
+version of our first tactic proof in this chapter:
 
 ```lean
 theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
@@ -209,7 +213,7 @@ block.
 
 For simple subgoals, it may not be worth selecting a subgoal using its
 tag, but you may still want to structure the proof. Lean also provides
-the "bullet" notation ``. <tactics>`` (or ``· <tactics>``) for
+the indentation-sensitive "bullet" notation ``. <tactics>`` (or ``· <tactics>``) for
 structuring proofs:
 
 ```lean

--- a/tactics.md
+++ b/tactics.md
@@ -53,7 +53,7 @@ separated by semicolons or line breaks. You can prove the above theorem
 in this way:
 
 ```lean
-theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := be
+theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
      apply And.intro
      exact hp
      apply And.intro
@@ -97,7 +97,8 @@ subgoals:
     ⊢ q ∧ p
 ```
 
-Spelling out this `apply` step: `And.intro` is `a → b → a ∧ b`; unifying the conclusion `a ∧ b` with the goal `p ∧ q ∧ p`
+Spelling out this `apply` step: `And.intro` is the rule `a → b → a ∧ b`; unifying its conclusion, `a ∧ b`,
+with the current goal `p ∧ q ∧ p`,
 gives us `p` for `a`, and `q ∧ p` for `b`; thus, we get `p` and `q ∧ p` as the new subgoals.
 
 The first of these two new subgoals is met (discharged) with the command ``exact hp``. The ``exact``

--- a/tactics.md
+++ b/tactics.md
@@ -47,23 +47,25 @@ above, Lean will report that it is exactly this goal that has been
 left unsolved.
 
 Ordinarily, you meet such a goal by writing an explicit term. But
-wherever a term is expected, Lean allows us to insert instead a ``by
-<tactics>`` block, where ``<tactics>`` is a sequence of commands,
-separated by semicolons or line breaks. You can prove the theorem above
-in that way:
+wherever a term is expected, Lean lets us insert a ``by
+<tactics>`` block instead, where ``<tactics>`` is a sequence of commands,
+separated by semicolons or line breaks. You can prove the above theorem
+in this way:
 
 ```lean
-theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p :=
-  by apply And.intro
+theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := be
+     apply And.intro
      exact hp
      apply And.intro
      exact hq
      exact hp
 ```
 
-We often put the ``by`` keyword on the preceding line, and write the
-example above as:
+(We often put the ``by`` keyword on the preceding line.) 
 
+<!-- repeating the proof is a bit wasteful here.
+
+writing this example as:
 ```lean
 theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
   apply And.intro
@@ -72,12 +74,13 @@ theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
   exact hq
   exact hp
 ```
+-->
 
-The ``apply`` tactic applies an expression, viewed as denoting a
-function with zero or more arguments. It unifies the conclusion with
-the expression in the current goal, and creates new goals for the
-remaining arguments, provided that no later arguments depend on
-them. In the example above, the command ``apply And.intro`` yields two
+The ``apply <e>`` tactic applies an expression `<e>`, viewed as a
+function of zero or more arguments. It unifies the conclusion (that is, the result of applying `e`)
+with the current goal expression, and creates new goals for the
+arguments of `e`, provided that no later arguments depend on them.
+In the example above, the command ``apply And.intro`` yields two
 subgoals:
 
 ```
@@ -94,7 +97,10 @@ subgoals:
     ⊢ q ∧ p
 ```
 
-The first goal is met with the command ``exact hp``. The ``exact``
+Spelling out this `apply` step: `And.intro` is `a → b → a ∧ b`; unifying the conclusion `a ∧ b` with the goal `p ∧ q ∧ p`
+gives us `p` for `a`, and `q ∧ p` for `b`; thus, we get `p` and `q ∧ p` as the new subgoals.
+
+The first of these two new subgoals is met (discharged) with the command ``exact hp``. The ``exact``
 command is just a variant of ``apply`` which signals that the
 expression given should fill the goal exactly. It is good form to use
 it in a tactic proof, since its failure signals that something has
@@ -102,6 +108,10 @@ gone wrong. It is also more robust than ``apply``, since the
 elaborator takes the expected type, given by the target of the goal,
 into account when processing the expression that is being applied. In
 this case, however, ``apply`` would work just as well.
+
+The second subgoal is similarly discharged with `apply And.intro`,
+followed by `exact hq` and `exact hp`, which discharge the two new subgoals.
+<!-- could include a tree representation of the proof here -->
 
 You can see the resulting proof term with the ``#print`` command:
 
@@ -115,9 +125,18 @@ You can see the resulting proof term with the ``#print`` command:
 #print test
 ```
 
-You can write a tactic script incrementally. In VS Code, you can open
-a window to display messages by pressing ``Ctrl-Shift-Enter``, and
-that window will then show you the current goal whenever the cursor is
+Lean will print:
+```
+∀ (p q : Prop), p → q → p ∧ q ∧ p :=
+                fun p q hp hq => { left := hp, right := { left := hq, right := hp } }
+```
+
+This is the actual proof term that the tactics constructed. It can now be verified independently
+of the tactics and the rest of the Lean machinery if we so choose, by a trusted third-party tool, for example.
+
+You can write a tactic script incrementally. In VS Code, open
+a window to display messages by pressing ``Ctrl-Shift-Enter``.
+That window will then show you the current goal whenever the cursor is
 in a tactic block. In Emacs, you can see the goal at the end of any
 line by pressing ``C-c C-g``, or see the remaining goal in an
 incomplete proof by putting the cursor after the first character of
@@ -144,14 +163,14 @@ Unsurprisingly, it produces exactly the same proof term.
 #print test
 ```
 
-Multiple tactic applications can be written in a single line by concatenating with a semicolon.
+Multiple tactic applications can be written in a single line, concatenated with semicolons:
 
 ```lean
 theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
   apply And.intro hp; exact And.intro hq hp
 ```
 
-Tactics that may produce multiple subgoals often tag them. For
+Tactics that may produce multiple subgoals often *tag* them. For
 example, the tactic ``apply And.intro`` tagged the first subgoal as
 ``left``, and the second as ``right``. In the case of the ``apply``
 tactic, the tags are inferred from the parameters' names used in the
@@ -182,7 +201,7 @@ theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by
   case left => exact hp
 ```
 
-Note that Lean hides the other goals inside the ``case`` block. We say
+Note that Lean hides the other goals inside the ``case`` block. We say that
 it is "focusing" on the selected goal.  Moreover, Lean flags an error
 if the selected goal is not fully solved at the end of the ``case``
 block.
@@ -190,7 +209,7 @@ block.
 For simple subgoals, it may not be worth selecting a subgoal using its
 tag, but you may still want to structure the proof. Lean also provides
 the "bullet" notation ``. <tactics>`` (or ``· <tactics>``) for
-structuring proof.
+structuring proofs:
 
 ```lean
 theorem test (p q : Prop) (hp : p) (hq : q) : p ∧ q ∧ p := by


### PR DESCRIPTION
Streamline some language and add clarifications. The more substantial changes are:

- Introducing arguments in a way consistent with the idea that functions really only take one argument at a time (currying); the current formulation might mislead the reader into thinking otherwise.

- Expand the first `apply` tactic example, showing what gets unified and how the subgoals are generated.
