### PR TITLE
fix typo for double Int

### DIFF
--- a/type_classes.md
+++ b/type_classes.md
@@ -105,7 +105,7 @@ def double [Add a] (x : a) : a :=
 -- 20
 
 #eval double (10 : Int)
--- 100
+-- 20
 
 #eval double (7 : Float)
 -- 14.000000


### PR DESCRIPTION
I believe `100` here is a mistake, copied from `Nat.mul` above. 
BTW, I can't get the point of the useless type annotation `: Int`.