### PR TITLE
Update wording in DependentTypeTheory.lean

### DIFF
--- a/book/TPiL/DependentTypeTheory.lean
+++ b/book/TPiL/DependentTypeTheory.lean
@@ -957,8 +957,8 @@ namespace Foo
 end Foo
 ```
 
-Like sections, nested namespaces have to be closed in the order they
-are opened. Namespaces and sections serve different purposes:
+Like sections, nested namespaces have to be closed in the reverse order of their opening.
+Namespaces and sections serve different purposes:
 namespaces organize data and sections declare variables for insertion
 in definitions. Sections are also useful for delimiting the scope of
 commands such as {kw}`set_option` and {kw}`open`.


### PR DESCRIPTION
I am being pedantic here but the following sentence is technically incorrect as it is written:

"Like sections, nested namespaces have to be closed in the order they are opened"

The intended meaning is that they should be closed in the reverse order. I suggest an alternative wording here, but perhaps another alternative could be saying "last-in, first-out" more directly.