### PR TITLE
Add missing "set_option linter.unusedVariables false"

### DIFF
--- a/book/TPiL/PropositionsAndProofs.lean
+++ b/book/TPiL/PropositionsAndProofs.lean
@@ -217,7 +217,7 @@ can be proved using lambda abstraction and application. In Lean, the
 
 ```lean
 set_option linter.unusedVariables false
----
+------
 variable {p : Prop}
 variable {q : Prop}
 


### PR DESCRIPTION
without this `hq` is marked with the "unused variable `hq`" warning.