### PR TITLE
Typo in Chap. 7

### DIFF
--- a/book/TPiL/InductiveTypes.lean
+++ b/book/TPiL/InductiveTypes.lean
@@ -690,7 +690,7 @@ structure Semigroup where
 We will see more examples in the chapter on {ref "structures-and-records"}[structures and records].
 
 :::leanFirst
-We have already discussed the dependent product type {leanRef}`Sigma`:
+We have already discussed the dependent sum type {leanRef}`Sigma`:
 
 ```lean
 namespace Hidden


### PR DESCRIPTION
In ./book/TPiL/InductiveTypes.lean:693 the `dependent product type` should be the `dependent sum type`.