### PR TITLE
Fix rw explanation in Tactics chapter

### DIFF
--- a/book/TPiL/Tactics.lean
+++ b/book/TPiL/Tactics.lean
@@ -1309,8 +1309,8 @@ Get the intermediate proof states from `rw` into the reference ring to help thes
 
 In the first example above, the first step rewrites {leanRef}`a + b + c` to
 {leanRef}`a`{lit}` + (`{leanRef}`b + c`{lit}`)`. The next step applies commutativity to the term
-{leanRef}`b + c`; without specifying the argument, the tactic would instead rewrite
-{leanRef}`a`{lit}` + (`{leanRef}`b + c`{lit}`)` to {lit}`(`{leanRef}`b + c`{lit}`) + `{leanRef}`a`. Finally, the last step applies
+{leanRef}`b + c`; the tactic would instead rewrite
+{leanRef}`a`{lit}` + (`{leanRef}`b + c`{lit}`)` to {leanRef}`a`{lit}` + (`{leanRef}`c + b`{lit}`)`. Finally, the last step applies
 associativity in the reverse direction, rewriting {leanRef}`a`{lit}` + (`{leanRef}`c`{lit}`  +  `{leanRef}`b`{lit}`)` to
 {leanRef}`a + c + b`. The next two examples instead apply associativity to
 move the parenthesis to the right on both sides, and then switch {leanRef}`b`


### PR DESCRIPTION
For this example
```
example (a b c : Nat) : a + b + c = a + c + b := by
  rw [Nat.add_assoc, Nat.add_comm b, ← Nat.add_assoc]

```

This PR fixes a documentation error in the `rw` tactic explanation in `book/TPiL/Tactics.lean`.

The text previously said that, without specifying the argument, rewriting
  `a + (b + c)` with `Nat.add_comm` would produce `(b + c) + a`.
  That is incorrect for this example.

It now correctly states that the rewrite is:
  `a + (b + c)` -> `a + (c + b)`.