### PR TITLE
docs: add note clarifying sigma / pi type naming convention discrepancy

### DIFF
--- a/book/TPiL/DependentTypeTheory.lean
+++ b/book/TPiL/DependentTypeTheory.lean
@@ -1039,6 +1039,7 @@ as a family of types over {lean}`α`, that is, a type {lean}`β a` for each
 of functions {lean}`f` with the property that, for each {lean}`a : α`, {lean}`f a`
 is an element of {lean}`β a`. In other words, the type of the value
 returned by {lean}`f` depends on its input.
+
 :::
 
 :::setup
@@ -1079,6 +1080,8 @@ are also called _sigma_ types, and you can also write them as
 dependent pair.  The {lit}`⟨` and {lit}`⟩` characters may be typed with
 {kbd}`\langle` and {kbd}`\rangle` or {kbd}`\<` and {kbd}`\>`, respectively.
 :::
+
+Note that there are lots of external sources referring to $`\Sigma`-types as dependent sum types and $`\Pi`-types as dependent product types, a naming convention rooted in their respective symbolic notations. In this book we employ the terms "dependent arrow type" and "dependent product type" as they more accurately align with the semantic roles of the two constructions.
 
 ```lean
 universe u v


### PR DESCRIPTION
The terminology in the book might confuse those who are new to type theory.

## Problem
External sources sometimes refer to the $\Sigma$-type as the dependent sum type, whereas TPiL calls it the dependent product.

## Solution
Added a line of prose for clarification at `book/TPiL/DependentTypeTheory.lean:1084`

## Misc
Related zulip chat: [here in channel #lean4](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Typo.20Fix.20in.20Chapter.207.20for.20TPiL4/with/606970637)